### PR TITLE
[WIP] Dark Mode Tweaks

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -120,7 +120,7 @@ code {
     padding-left: var(--jp-code-padding);
     padding-right: 20px;
     border: none;
-    background-color: rgb(255, 255, 255);
+    background-color: transparent;
     cursor: text;
     line-height: var(--jp-content-line-height);
 }


### PR DESCRIPTION
Playing with this on binder: looking great!

With the stock JupyterLab dark theme, after highlighting a prosemirror and then selecting another cell, the unselected editor has white-on-white text.
![Screenshot from 2019-08-17 12-29-52](https://user-images.githubusercontent.com/45380/63214784-bb5faa80-c0ea-11e9-9911-065a87ce8d6c.png)

This just sets the background to transparent.
![Screenshot from 2019-08-17 12-31-03](https://user-images.githubusercontent.com/45380/63214799-e4803b00-c0ea-11e9-9ff6-d9a841209dc9.png)

Could use a `var(--jp-`, but it seems like less is probably more, if the goal is trying to make the editing experience feel seamless, this should be the most predictable across themes. Just unsetting it inherits some other styling which disappears when you actually select it. Not nice.

Will keep investigating some other things!